### PR TITLE
Allow newer rubyzip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,13 @@ PATH
   specs:
     docx_templater (0.2.3)
       htmlentities (~> 4.3.1)
-      rubyzip (~> 1.1)
+      rubyzip (>= 1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    htmlentities (4.3.1)
+    htmlentities (4.3.4)
     rake (10.1.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -19,7 +19,7 @@ GEM
     rspec-expectations (2.14.3)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
-    rubyzip (1.1.0)
+    rubyzip (1.2.1)
 
 PLATFORMS
   ruby
@@ -28,3 +28,6 @@ DEPENDENCIES
   docx_templater!
   rake (~> 10.1)
   rspec (~> 2.14)
+
+BUNDLED WITH
+   1.14.4

--- a/docx_templater.gemspec
+++ b/docx_templater.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
     "lib/docx/newline_replacer.rb",
     "lib/docx/nodes_to_fix.rb",
     "lib/docx/placeholder_observer.rb"]
-  s.add_runtime_dependency "rubyzip", "~> 1.1"
+  s.add_runtime_dependency "rubyzip", ">= 1.1"
   s.add_runtime_dependency "htmlentities", "~> 4.3.1"
   s.add_development_dependency "rake", "~> 10.1"
   s.add_development_dependency "rspec", "~> 2.14"


### PR DESCRIPTION
There is a security issue in rubyzip was just fixed by https://github.com/rubyzip/rubyzip/issues/315,
however, the rubyzip used in docx_templater is locked to `~> 1.1`. 