### PR TITLE
Add support for different tags

### DIFF
--- a/lib/docx/document_replacer.rb
+++ b/lib/docx/document_replacer.rb
@@ -8,7 +8,7 @@ module Docx
 
     def initialize(str, data_provider, opts = {})
       @doc = REXML::Document.new(str)
-      @observer = Docx::PlaceholderObserver.new(data_provider)
+      @observer = Docx::PlaceholderObserver.new(data_provider, opts)
       walk_node(doc.root)
       @observer.end_of_document
       convert_newlines if opts.fetch(:convert_newlines){ true }

--- a/spec/lib/docx/placeholder_observer_spec.rb
+++ b/spec/lib/docx/placeholder_observer_spec.rb
@@ -8,46 +8,86 @@ describe Docx::PlaceholderObserver do
       r.stub(:has_key? => true)
       r
     end
-    it "finds placeholders as it is given text nodes" do
-      data_provider.should_receive(:[]).with(:title).and_return("The Thing")
-      n1 = REXML::Text.new("dflkja sdf ||title|| slkjasdlkj")
-      n1.should_receive(:value=).with('dflkja sdf The Thing slkjasdlkj')
 
-      subject.next_node(n1)
-      subject.end_of_document
+    shared_examples 'test delimiter' do
+      it "finds placeholders as it is given text nodes" do
+        data_provider.should_receive(:[]).with(:title).and_return("The Thing")
+        n1 = REXML::Text.new("dflkja sdf #{delimiter}title#{delimiter} slkjasdlkj")
+        n1.should_receive(:value=).with('dflkja sdf The Thing slkjasdlkj')
+
+        subject.next_node(n1)
+        subject.end_of_document
+      end
+
+
+      it "handles multiple placeholders in a single node correctly" do
+        data_provider.should_receive(:[]).with(:title).and_return('Zombie Apocalypse')
+        data_provider.should_receive(:[]).with(:subject).and_return('Movie')
+        n1 = REXML::Text.new("#{delimiter}title#{delimiter} is a #{delimiter}subject#{delimiter}. Okay?")
+
+        subject.next_node(n1)
+        subject.end_of_document
+        n1.value.should == 'Zombie Apocalypse is a Movie. Okay?'
+      end
+
+      it "handles nil replacements" do
+        data_provider.should_receive(:[]).with(:title).and_return(nil)
+        n1 = REXML::Text.new("#{delimiter}title#{delimiter}")
+        subject.next_node(n1)
+        subject.end_of_document
+        n1.value.should == ''
+      end
     end
 
-    it "finds placeholders among several nodes" do
-      data_provider.should_receive(:[]).with(:title).and_return('The Thing')
-      n1 = REXML::Text.new('booyah, (&&IJH))OJ |')
-      n1.should_receive(:value=).with('booyah, (&&IJH))OJ The Thing')
-      n2 = REXML::Text.new('|tit')
-      n2.should_receive(:value=).with('')
-      n3 = REXML::Text.new('le|| asdf093n38hfaj')
-      n3.should_receive(:value=).with(' asdf093n38hfaj')
+    context 'default delimiter' do
+      let(:delimiter) { '||' }
+      subject{ Docx::PlaceholderObserver.new(data_provider) }
 
-      subject.next_node(n1)
-      subject.next_node(n2)
-      subject.next_node(n3)
-      subject.end_of_document
+      include_examples 'test delimiter'
+
+      it "finds placeholders among several nodes" do
+        data_provider.should_receive(:[]).with(:title).and_return('The Thing')
+        n1 = REXML::Text.new('booyah, (&&IJH))OJ |')
+        n1.should_receive(:value=).with('booyah, (&&IJH))OJ The Thing')
+        n2 = REXML::Text.new('|tit')
+        n2.should_receive(:value=).with('')
+        n3 = REXML::Text.new('le|| asdf093n38hfaj')
+        n3.should_receive(:value=).with(' asdf093n38hfaj')
+
+        subject.next_node(n1)
+        subject.next_node(n2)
+        subject.next_node(n3)
+        subject.end_of_document
+      end
     end
 
-    it "handles multiple placeholders in a single node correctly" do
-      data_provider.should_receive(:[]).with(:title).and_return('Zombie Apocalypse')
-      data_provider.should_receive(:[]).with(:subject).and_return('Movie')
-      n1 = REXML::Text.new('||title|| is a ||subject||. Okay?')
+    context 'custom delimiter' do
+      let(:delimiter) { '#' }
+      subject{ Docx::PlaceholderObserver.new(data_provider, delimiter: delimiter) }
 
-      subject.next_node(n1)
-      subject.end_of_document
-      n1.value.should == 'Zombie Apocalypse is a Movie. Okay?'
+      include_examples 'test delimiter'
     end
 
-    it "handles nil replacements" do
-      data_provider.should_receive(:[]).with(:title).and_return(nil)
-      n1 = REXML::Text.new('||title||')
-      subject.next_node(n1)
-      subject.end_of_document
-      n1.value.should == ''
+    context 'when delimiter is blank' do
+      let(:delimiter) { ' ' }
+      it 'raises an error' do
+        expect{ Docx::PlaceholderObserver.new(data_provider, delimiter: delimiter) }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when delimiter is nil' do
+      let(:delimiter) { nil }
+      it 'raises an error' do
+        expect{ Docx::PlaceholderObserver.new(data_provider, delimiter: delimiter) }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when delimiter contains different chars' do
+      let(:delimiter) { '|#' }
+
+      it 'raises an error' do
+        expect{ Docx::PlaceholderObserver.new(data_provider, delimiter: delimiter) }.to raise_error ArgumentError
+      end
     end
   end
 end


### PR DESCRIPTION
Use ```:delimiter``` option to configure tags delimiter:
```ruby
DocxTemplater.new(delimiter: '#').replace_file_with_content('path/to/file.docx', replacements )
```
If no ```:delimiter``` option is specified, '||' is used by default .