### PR TITLE
Fix newline conversion

### DIFF
--- a/lib/docx/newline_replacer.rb
+++ b/lib/docx/newline_replacer.rb
@@ -19,7 +19,9 @@ module Docx
 
     def replace_text_node_or_continue_walking(node, child)
       if child.node_type == :text
-        replace_text_node(node, child) if child.to_s.include?("\n")
+        if (node.node_type == :element && node.expanded_name == 'w:t') && child.to_s.include?("\n")
+          replace_text_node(node, child)
+        end
       else
         walk(child)
       end

--- a/lib/docx/newline_replacer.rb
+++ b/lib/docx/newline_replacer.rb
@@ -19,7 +19,7 @@ module Docx
 
     def replace_text_node_or_continue_walking(node, child)
       if child.node_type == :text
-        replace_text_node(node, child)
+        replace_text_node(node, child) if child.to_s.include?("\n")
       else
         walk(child)
       end

--- a/lib/docx/newline_replacer.rb
+++ b/lib/docx/newline_replacer.rb
@@ -26,27 +26,30 @@ module Docx
     end
 
     def replace_text_node(parent, node)
+      grand_parent = parent.parent
       list_of_new_nodes(node).reverse.each do |new_node|
-        parent.insert_after(node, new_node)
+        grand_parent.insert_after(parent, new_node)
       end
-      node.remove
+      parent.remove
     end
 
     def line_break_node
-      br = REXML::Element.new('w:br')
+      REXML::Element.new('w:br')
     end
 
     def list_of_new_nodes(node)
        node.to_s.split("\n")
         .map{|str| str_to_text_node(str)}
-        .flat_map{ |txt| [txt, line_break_node] }[0..-2]
+        .flat_map{ |txt_node| [txt_node, line_break_node] }[0..-2]
     end
 
     def str_to_text_node(str)
       respect_whitespace = true
       parent = nil
       raw_text = true
-      REXML::Text.new(str, respect_whitespace, parent, raw_text)
+      t = REXML::Element.new('w:t')
+      text = REXML::Text.new(str, respect_whitespace, parent, raw_text)
+      t.add_text text
     end
   end
 end

--- a/spec/functional/newline_conversion_spec.rb
+++ b/spec/functional/newline_conversion_spec.rb
@@ -17,7 +17,7 @@ describe "DocxTemplater :convert_newlines" do
     let(:options){ {convert_newlines: true} }
     it "can convert newlines with docx equivalents" do
       body.should_not include("||quotes||")
-      body.should include("<w:t>Be excellent to eachother ~Bill and Ted<w:br/>Typing is not the bottlneck<w:br/>Do something awesome.</w:t>")
+      body.should include("<w:t>Be excellent to eachother ~Bill and Ted</w:t><w:br/><w:t>Typing is not the bottlneck</w:t><w:br/><w:t>Do something awesome.</w:t>")
     end
 
     it "does not double escape special characters" do
@@ -37,7 +37,7 @@ describe "DocxTemplater :convert_newlines" do
   context "default" do
     let(:options){ {} }
     it "converts newlines" do
-      body.should include("Bill and Ted<w:br/>Typing")
+      body.should include("Bill and Ted</w:t><w:br/><w:t>Typing")
     end
   end
 end

--- a/spec/lib/docx/newline_replacer_spec.rb
+++ b/spec/lib/docx/newline_replacer_spec.rb
@@ -1,13 +1,19 @@
 require 'spec_helper'
+require 'spec_helper'
 
 describe Docx::NewlineReplacer do
-  let(:xml_str){ "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><w:hdr xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:t>Leslie\nKnope</w:t></w:hdr>" }
+  let(:xml_str){ "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><w:hdr xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:t>Leslie\nKnope</w:t><w:pict>\n              </w:pict></w:hdr>" }
   let(:xml_doc){ REXML::Document.new(xml_str) }
   let(:replacer){ Docx::NewlineReplacer.new(xml_doc) }
 
-  it "it replaces \\n with <w:br/>" do
+  it "it replaces \\n with <w:br/> in text nodes" do
     replacer.replace
     xml_doc.to_s.should include("<w:t>Leslie</w:t><w:br/><w:t>Knope</w:t>")
+  end
+
+  it "it does not replace \\n with <w:br/> in not text nodes" do
+    replacer.replace
+    xml_doc.to_s.should include("<w:pict>\n              </w:pict>")
   end
 
   context "multiple newlines" do

--- a/spec/lib/docx/newline_replacer_spec.rb
+++ b/spec/lib/docx/newline_replacer_spec.rb
@@ -7,7 +7,7 @@ describe Docx::NewlineReplacer do
 
   it "it replaces \\n with <w:br/>" do
     replacer.replace
-    xml_doc.to_s.should include("<w:t>Leslie<w:br/>Knope</w:t>")
+    xml_doc.to_s.should include("<w:t>Leslie</w:t><w:br/><w:t>Knope</w:t>")
   end
 
   context "multiple newlines" do
@@ -16,8 +16,7 @@ describe Docx::NewlineReplacer do
     it "replaces all newlines in a single node" do
       replacer.replace
       str = xml_doc.to_s
-      str.should include("Leslie<w:br/>Knope")
-      str.should include("Ben<w:br/>Wyatt")
+      str.should include("<w:t>Leslie</w:t><w:br/><w:t>Knope</w:t><w:br/><w:t>loves</w:t><w:br/><w:t>Ben</w:t><w:br/><w:t>Wyatt</w:t>")
     end
   end
 end


### PR DESCRIPTION
Office365 does not display <w:t> with <w:br /> inside properly.
This pull request adds changes to replace new line with `<w:t>line 1</w:t><w:br /><w:t>line 2</w:t>`